### PR TITLE
Add Screenshot Key F12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ obj
 =======
 # make sure we're not committing actual U7 stuff
 resources/Data/U7/*
+
+# ignore screenshots
+resources/*.png

--- a/game/src/Geist/Engine.cpp
+++ b/game/src/Geist/Engine.cpp
@@ -5,6 +5,7 @@
 #include "Logging.h"
 #include <sstream>
 #include <fstream>
+#include <time.h>
 using namespace std;
 
 void Engine::Init(const std::string& configfile)
@@ -45,6 +46,13 @@ void Engine::Update()
 		m_Done = true;
 	}
 
+	// F12 takes a screenshot
+	if (IsKeyPressed(KEY_F12))
+	{
+		CaptureScreenshot();
+	}
+
+	// F9 toggles the debug drawing
 	if (IsKeyPressed(KEY_F9))
 	{
 		m_debugDrawing = !m_debugDrawing;
@@ -66,4 +74,15 @@ void Engine::Draw()
 	}
 
 	EndDrawing();
+}
+
+void Engine::CaptureScreenshot() {
+	char filename[40];
+	struct tm* timenow;
+
+	time_t now = time(NULL);
+	timenow = gmtime(&now);
+
+	strftime(filename, sizeof(filename), "screenshot_%Y-%m-%d_%H_%M_%S.png", timenow);
+	TakeScreenshot(filename);
 }

--- a/game/src/Geist/Engine.h
+++ b/game/src/Geist/Engine.h
@@ -29,6 +29,8 @@ public:
 	virtual void Update();
 	virtual void Draw();
 
+	void CaptureScreenshot();
+
 
 	Config        m_EngineConfig;
 	bool          m_Done;


### PR DESCRIPTION
- Use `F12` to take a screenshot, stored in the `Resources` folder
- Helps with sharing to social or preserving memories 

![screenshot_2024-06-18_01_16_07](https://github.com/ViridianGames/U7Revisited/assets/962434/6ec4dfc9-3145-4014-a85a-4a53501e519e)

