### PR TITLE
Use Engine Configuration to Define U7 Data Path

### DIFF
--- a/game/src/LoadingState.cpp
+++ b/game/src/LoadingState.cpp
@@ -220,8 +220,12 @@ void LoadingState::LoadVersion()
 
 void LoadingState::LoadChunks()
 {
+	std::string dataPath = g_Engine->m_EngineConfig.GetString("data_path");
+	
 	//  Load data for all chunks first
-	FILE* u7chunksfile = fopen("Data/U7/blackgate/STATIC/U7CHUNKS", "rb");
+	std::string loadingPath(dataPath);
+	loadingPath.append("/STATIC/U7CHUNKS");
+	FILE* u7chunksfile = fopen(loadingPath.c_str(), "rb");
 	if (u7chunksfile == nullptr)
 	{
 		Log("Ultima VII files not found.  They should go into the Data/U7 folder.");
@@ -254,7 +258,11 @@ void LoadingState::LoadChunks()
 
 void LoadingState::LoadMap()
 {
-	FILE* u7mapfile = fopen("Data/U7/blackgate/STATIC/U7MAP", "rb");
+	std::string dataPath = g_Engine->m_EngineConfig.GetString("data_path");
+	std::string loadingPath(dataPath);
+	loadingPath.append("/STATIC/U7MAP");
+	FILE* u7mapfile = fopen(loadingPath.c_str(), "rb");
+
 	//  Untangle the map and chunk files into a single array.
 	//  Create the map of chunk ids and chunk data
 	int k = 0;
@@ -282,6 +290,10 @@ void LoadingState::LoadMap()
 
 void LoadingState::LoadIFIX()
 {
+	std::string dataPath = g_Engine->m_EngineConfig.GetString("data_path");
+	std::string loadingPath(dataPath);
+	loadingPath.append("/STATIC/");
+
 	for (int superchunky = 0; superchunky < 12; ++superchunky)
 	{
 		for (int superchunkx = 0; superchunkx < 12; ++superchunkx)
@@ -300,7 +312,7 @@ void LoadingState::LoadIFIX()
             
             std::transform(s.begin(), s.end(), s.begin(), ::toupper);
             
-            s.insert(0, "Data/U7/blackgate/STATIC/");
+						s.insert(0, loadingPath.c_str());
 
 			FILE* u7thisifix = fopen(s.c_str(), "rb");
             
@@ -439,6 +451,10 @@ void LoadingState::MakeMap()
 
 void LoadingState::LoadIREG()
 {
+	std::string dataPath = g_Engine->m_EngineConfig.GetString("data_path");
+	std::string loadingPath(dataPath);
+	loadingPath.append("/GAMEDAT/");
+
 	for (int superchunky = 0; superchunky < 12; ++superchunky)
 	{
 		for (int superchunkx = 0; superchunkx < 12; ++superchunkx)
@@ -457,7 +473,7 @@ void LoadingState::LoadIREG()
             
          std::transform(s.begin(), s.end(), s.begin(), ::toupper);
             
-         s.insert(0, "Data/U7/blackgate/GAMEDAT/");
+				 s.insert(0, loadingPath.c_str());
 
 			FILE* u7thisireg = fopen(s.c_str(), "rb");
 
@@ -522,7 +538,10 @@ void LoadingState::CreateShapeTable()
 {
 	//  Load palette data
 	ifstream palette;
-	palette.open("Data/U7/blackgate/STATIC/PALETTES.FLX", ios::binary);
+	std::string dataPath = g_Engine->m_EngineConfig.GetString("data_path");
+	std::string loadingPath(dataPath);
+	loadingPath.append("/STATIC/PALETTES.FLX");
+	palette.open(loadingPath.c_str(), ios::binary);
 	if (!palette.good())
 	{
 		Log("Ultima VII files not found.  They should go into the Data/U7/blackgate folder.");
@@ -554,7 +573,8 @@ void LoadingState::CreateShapeTable()
 
 	//  Load shape data
 	ifstream shapesFile;
-	shapesFile.open("Data/U7/blackgate/STATIC/SHAPES.VGA", ios::binary);
+	std::string shapePath = dataPath.append("/STATIC/SHAPES.VGA");
+	shapesFile.open(shapePath.c_str(), ios::binary);
 
 	stringstream shapes;
 	shapes << shapesFile.rdbuf();
@@ -733,21 +753,21 @@ void LoadingState::CreateShapeTable()
 void LoadingState::CreateObjectTable()
 {
 	//  Open the two files that define the objects in the object table.
-	std::stringstream tfa;
+	// Open the two files that define the objects in the object table.
+	std::string dataPath = g_Engine->m_EngineConfig.GetString("data_path");
 
-	tfa << "Data/U7/blackgate/STATIC/TFA.DAT";
+	std::stringstream tfa;
+	tfa << dataPath.c_str() << "/STATIC/TFA.DAT";
 
 	ifstream tfafile(tfa.str(), ios::binary);
 
 	std::stringstream wgtvol;
-
-	wgtvol << "Data/U7/blackgate/STATIC/WGTVOL.DAT";
+	wgtvol << dataPath.c_str() << "/STATIC/WGTVOL.DAT";
 
 	ifstream wgtvolfile(wgtvol.str(), ios::binary);
 
 	std::stringstream text;
-
-	text << "Data/U7/blackgate/STATIC/TEXT.FLX";
+	text << dataPath.c_str() << "/STATIC/TEXT.FLX";
 
 	ifstream textfile(text.str(), ios::binary);
 

--- a/resources/Data/engine.cfg
+++ b/resources/Data/engine.cfg
@@ -1,6 +1,10 @@
 # Global parameters
 name = Ultima VII Revisited
 
+# Path to your U7 folder
+# should be something like "Data/U7" or "Data/U7/blackgate"
+data_path = Data/U7
+
 # 320x180, 640x360, 800x450, 960x540, 1280x720, 1600x900, 1920x1080
 # Screen parameters
 h_res = 1600


### PR DESCRIPTION
- Update the `LoadingState` to use a configuration value for the U7 data
- I have the GOG version of Ultima7, but have neither the blackgate or serpentisle folders (so others might run into this issue -- maybe?)