### PR TITLE
Update LoadingState.cpp

### DIFF
--- a/Source/LoadingState.cpp
+++ b/Source/LoadingState.cpp
@@ -1061,7 +1061,7 @@ void LoadingState::LoadInitialGameState()
 
 	vector<FLXEntryData> subFileMap = ParseFLXHeader(subFiles);
 
-	for (auto& node = subFileMap.begin(); node != subFileMap.end(); ++node)
+	for (auto&& node = subFileMap.begin(); node != subFileMap.end(); ++node)
 	{
 		subFiles.seekg(node->offset);
 		//  First thirteen characters are the filename.


### PR DESCRIPTION
Modify function calls to accept a const reference, allowing temporary objects or literals to be passed safely. If not, this result on an error with gcc on linux. To be tested, don't know if it works but make works now on linux with gcc 11.4 on ubuntu.