### PR TITLE
Calculate object visibility in partitions

### DIFF
--- a/Source/U7Globals.h
+++ b/Source/U7Globals.h
@@ -249,6 +249,15 @@ U7Object* U7ObjectClassFactory(int type);
 
 void PopulateLocationMap();
 
+/// @brief Update an object's chunk when it has moved
+/// @param object The object that moved
+/// @param fromPos The object's prevous position
+void UpdateObjectChunk(U7Object* object, Vector3 fromPos);
+
+/// @brief Assign an object into a chunk (world partition for visibility).
+/// @param object The object to assign
+void AssignObjectChunk(U7Object* object);
+
 void UpdateSortedVisibleObjects();
 
 Vector3 GetRadialVector(float partitions, float thispartition);

--- a/Source/U7Gump.cpp
+++ b/Source/U7Gump.cpp
@@ -187,7 +187,7 @@ void Gump::Update()
 		//  Dragging from inventory to inventory
 
 		auto object = GetObjectFromID(m_draggedObjectId);
-		object->m_Pos = g_dropPos;
+		object->SetPos(g_dropPos);
 
 		object->m_isContained = false;
 

--- a/Source/U7Object.cpp
+++ b/Source/U7Object.cpp
@@ -281,7 +281,7 @@ void U7Object::NPCUpdate()
 		//  If this update would take us beyond the destination, set the position to the destination
 		if(Vector3DistanceSqr(newPos, m_Dest) > Vector3DistanceSqr(m_Pos, m_Dest))
 		{
-			m_Pos = m_Dest;
+			SetPos(m_Pos);
 			m_isMoving = false;
 		}
 		else
@@ -301,8 +301,18 @@ void U7Object::NPCUpdate()
 	}
 }
 
+void U7Object::SetInitialPos(Vector3 pos) {
+	m_Pos = pos;
+	AssignObjectChunk(this);
+
+	SetPos(pos);
+	SetDest(pos);
+}
+
 void U7Object::SetPos(Vector3 pos)
 {
+	Vector3 fromPos = m_Pos;
+
 	m_Pos = pos;
 
 	Vector3 dims = Vector3{ 0, 0, 0 };
@@ -331,6 +341,8 @@ void U7Object::SetPos(Vector3 pos)
 	m_centerPoint = Vector3Add(m_Pos, { objectData->m_width / 2, objectData->m_height /2, objectData->m_depth / 2 });
 	m_terrainCenterPoint = m_centerPoint;
 	m_terrainCenterPoint.y = m_Pos.y;
+
+	UpdateObjectChunk(this, fromPos);
 }
 
 float U7Object::Pick()

--- a/Source/U7Object.h
+++ b/Source/U7Object.h
@@ -33,7 +33,7 @@ public:
    virtual Vector3 GetDest() { return m_Dest; }
    virtual float GetSpeed() { return m_speed; }
 
-   void SetInitialPos(Vector3 pos) { SetPos(pos); SetDest(pos); }
+   void SetInitialPos(Vector3 pos);
    virtual void SetPos(Vector3 pos);
    virtual void SetDest(Vector3 pos);
    virtual void SetSpeed(float speed) { m_speed = speed; }

--- a/meson.build
+++ b/meson.build
@@ -140,6 +140,7 @@ sources = files(
            'Source/ShapeEditorState.cpp',
            'Source/Terrain.cpp',
            'Source/TitleState.cpp',
+           'Source/U7GumpNumberBar.cpp',
            'Source/U7Globals.cpp',
            'Source/U7Gump.cpp',
            'Source/U7LuaFuncs.cpp',


### PR DESCRIPTION
Speeds up the update loop considerably by placing objects into chunks (192x192) and only processing objects for visibility from surrounding chunks.

Some notes:
* The choice of 192x192 was based on the existing 192x192 grid used by the data loader. It may be more performant to switch to larger chunks
* The globals file is getting a little large - it may be worth moving all tracking of objects into some kind of `U7World` static class for readability
* It might be beneficial to apply a similar strategy to determining which objects to update, but that was intentionally excluded from the PR to keep it focused